### PR TITLE
drivers: spi: spi_ambiq.c Standardized use of common spi_context functions

### DIFF
--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -201,7 +201,10 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 
 			/* More instruction bytes to send */
 			if (ctx->tx_len > 0) {
-				/* The instruction length can only be 0~AM_HAL_IOM_MAX_OFFSETSIZE. */
+                /*
+				 * The instruction length can only be:
+				 * 	0~AM_HAL_IOM_MAX_OFFSETSIZE.
+				 */
 				if (ctx->tx_len > AM_HAL_IOM_MAX_OFFSETSIZE - 1) {
 					spi_context_complete(ctx, dev, 0);
 					return -ENOTSUP;

--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -48,7 +48,7 @@ struct spi_ambiq_data {
 #else
 #define REG_STAT 0x248
 #endif
-#define IDLE_STAT     0x4
+#define IDLE_STAT	 0x4
 #define SPI_STAT(dev) (SPI_BASE + REG_STAT)
 #define SPI_WORD_SIZE 8
 
@@ -201,7 +201,7 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 
 			/* More instruction bytes to send */
 			if (ctx->tx_len > 0) {
-                /*
+				/*
 				 * The instruction length can only be:
 				 * 	0~AM_HAL_IOM_MAX_OFFSETSIZE.
 				 */
@@ -234,8 +234,8 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 				trans.uPeerInfo.ui32SpiChipSelect = iom_nce;
 #ifdef CONFIG_SPI_AMBIQ_DMA
 				if (AM_HAL_STATUS_SUCCESS !=
-				    am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
-								    pfnSPI_Callback, (void *)dev)) {
+					am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
+									pfnSPI_Callback, (void *)dev)) {
 					spi_context_complete(ctx, dev, 0);
 					return -EIO;
 				}
@@ -253,8 +253,8 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 				trans.uPeerInfo.ui32SpiChipSelect = iom_nce;
 #ifdef CONFIG_SPI_AMBIQ_DMA
 				if (AM_HAL_STATUS_SUCCESS !=
-				    am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
-								    pfnSPI_Callback, (void *)dev)) {
+					am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
+									pfnSPI_Callback, (void *)dev)) {
 					spi_context_complete(ctx, dev, 0);
 					return -EIO;
 				}
@@ -275,8 +275,8 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 		trans.uPeerInfo.ui32SpiChipSelect = iom_nce;
 #ifdef CONFIG_SPI_AMBIQ_DMA
 		if (AM_HAL_STATUS_SUCCESS !=
-		    am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
-						    pfnSPI_Callback, (void *)dev)) {
+			am_hal_iom_nonblocking_transfer(data->IOMHandle, &trans,
+							pfnSPI_Callback, (void *)dev)) {
 			spi_context_complete(ctx, dev, 0);
 			return -EIO;
 		}
@@ -372,7 +372,7 @@ static int spi_ambiq_init(const struct device *dev)
 	void *buf = NULL;
 
 	if (AM_HAL_STATUS_SUCCESS !=
-	    am_hal_iom_initialize((cfg->base - REG_IOM_BASEADDR) / cfg->size, &data->IOMHandle)) {
+		am_hal_iom_initialize((cfg->base - REG_IOM_BASEADDR) / cfg->size, &data->IOMHandle)) {
 		LOG_ERR("Fail to initialize SPI\n");
 		return -ENXIO;
 	}
@@ -438,35 +438,35 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 }
 #endif /* CONFIG_PM_DEVICE */
 
-#define AMBIQ_SPI_INIT(n)                                                                          \
-	PINCTRL_DT_INST_DEFINE(n);                                                                 \
-	static int pwr_on_ambiq_spi_##n(void)                                                      \
-	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
-		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
-		return 0;                                                                          \
-	}                                                                                          \
-	static void spi_irq_config_func_##n(void)                                                  \
-	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), spi_ambiq_isr,              \
-			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_INST_IRQN(n));                                                       \
-	};                                                                                         \
-	static struct spi_ambiq_data spi_ambiq_data##n = {                                         \
-		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),                                     \
-		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx)};                                    \
-	static const struct spi_ambiq_config spi_ambiq_config##n = {                               \
-		.base = DT_INST_REG_ADDR(n),                                                       \
-		.size = DT_INST_REG_SIZE(n),                                                       \
-		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
-		.irq_config_func = spi_irq_config_func_##n,                                        \
-		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
-	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \
-	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n,     \
-			      &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,         \
-			      &spi_ambiq_driver_api);
+#define AMBIQ_SPI_INIT(n)																		  \
+	PINCTRL_DT_INST_DEFINE(n);																 \
+	static int pwr_on_ambiq_spi_##n(void)													  \
+	{																						  \
+		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +					\
+				DT_INST_PHA(n, ambiq_pwrcfg, offset);							  \
+		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);		\
+		k_busy_wait(PWRCTRL_MAX_WAIT_US);												  \
+		return 0;																		  \
+	}																						  \
+	static void spi_irq_config_func_##n(void)												  \
+	{																						  \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), spi_ambiq_isr,			  \
+				DEVICE_DT_INST_GET(n), 0);											 \
+		irq_enable(DT_INST_IRQN(n));													   \
+	};																						 \
+	static struct spi_ambiq_data spi_ambiq_data##n = {										 \
+		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),									 \
+		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx)};									\
+	static const struct spi_ambiq_config spi_ambiq_config##n = {							   \
+		.base = DT_INST_REG_ADDR(n),													   \
+		.size = DT_INST_REG_SIZE(n),													   \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),									\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),										 \
+		.irq_config_func = spi_irq_config_func_##n,										\
+		.pwr_func = pwr_on_ambiq_spi_##n};												 \
+	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);										  \
+	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n,	 \
+				  &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		 \
+				  &spi_ambiq_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPI_INIT)

--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -172,13 +172,13 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 #endif
 
 	/* There's data to send */
-	if (ctx->tx_len) {
+	if (spi_context_tx_on(ctx)) {
 #ifdef CONFIG_SPI_AMBIQ_FULLDUPLEX
 		/* Ambiq SPI Full duplex is only supported for blocking transactions,
 		 * both fullduplex and halfduplex work in 4-wire mode, while in halfduplex
 		 * mode SPI can only do one direction transfer simultaniously
 		 */
-		if ((!(config->operation & SPI_HALF_DUPLEX)) && (ctx->rx_len)) {
+		if ((!(config->operation & SPI_HALF_DUPLEX)) && (spi_context_rx_on(ctx))) {
 			trans.eDirection = AM_HAL_IOM_FULLDUPLEX;
 			trans.bContinue = false;
 			trans.pui32RxBuffer = (uint32_t *)ctx->rx_buf;
@@ -199,30 +199,30 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 			trans.ui32InstrLen = 1;
 			spi_context_update_tx(ctx, 1, 1);
 
-			/* This is the start of RX */
-			if (ctx->rx_buf != NULL) {
-				/* More instruction bytes to send */
-				if (ctx->tx_len > 0) {
-					/* The instruction length can only be 0~AM_HAL_IOM_MAX_OFFSETSIZE. */
-					if (ctx->tx_len > AM_HAL_IOM_MAX_OFFSETSIZE - 1) {
-						spi_context_complete(ctx, dev, 0);
-						return -ENOTSUP;
-					}
-
-					/* Put the remaining TX data in instruction. */
-					trans.ui32InstrLen += ctx->tx_len;
-					for (int i = 0; i < trans.ui32InstrLen - 1; i++) {
-#if defined(CONFIG_SOC_SERIES_APOLLO3X)
-						trans.ui32Instr =
-							(trans.ui32Instr << 8) | (*ctx->tx_buf);
-#else
-						trans.ui64Instr =
-							(trans.ui64Instr << 8) | (*ctx->tx_buf);
-#endif
-						spi_context_update_tx(ctx, 1, 1);
-					}
+			/* More instruction bytes to send */
+			if (ctx->tx_len > 0) {
+				/* The instruction length can only be 0~AM_HAL_IOM_MAX_OFFSETSIZE. */
+				if (ctx->tx_len > AM_HAL_IOM_MAX_OFFSETSIZE - 1) {
+					spi_context_complete(ctx, dev, 0);
+					return -ENOTSUP;
 				}
 
+				/* Put the remaining TX data in instruction. */
+				trans.ui32InstrLen += ctx->tx_len;
+				for (int i = 0; i < trans.ui32InstrLen - 1; i++) {
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+					trans.ui32Instr =
+						(trans.ui32Instr << 8) | (*ctx->tx_buf);
+#else
+					trans.ui64Instr =
+						(trans.ui64Instr << 8) | (*ctx->tx_buf);
+#endif
+					spi_context_update_tx(ctx, 1, 1);
+				}
+			}
+
+			/* There's data to Receive */
+			if (spi_context_rx_on(ctx)) {
 				/* Set RX direction and receive data. */
 				trans.eDirection = AM_HAL_IOM_RX;
 				trans.bContinue = bContinue;
@@ -241,24 +241,7 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 #else
 				ret = am_hal_iom_blocking_transfer(data->IOMHandle, &trans);
 #endif
-			} else {
-                /* More instruction bytes to send */
-                /* The instruction length can only be 0~AM_HAL_IOM_MAX_OFFSETSIZE. */
-                if (ctx->tx_len > AM_HAL_IOM_MAX_OFFSETSIZE - 1) {
-                    spi_context_complete(ctx, dev, 0);
-                    return -ENOTSUP;
-                }
-
-                /* Put the remaining TX data in instruction. */
-                trans.ui32InstrLen += ctx->tx_len;
-                for (int i = 0; i < trans.ui32InstrLen - 1; i++) {
-#if defined(CONFIG_SOC_SERIES_APOLLO3X)
-                    trans.ui32Instr = (trans.ui32Instr << 8) | (*ctx->tx_buf);
-#else
-                    trans.ui64Instr = (trans.ui64Instr << 8) | (*ctx->tx_buf);
-#endif
-                    spi_context_update_tx(ctx, 1, 1);
-                }
+			} else { /* There's no data to Receive */
 				/* Set TX direction to send data. */
 				trans.eDirection = AM_HAL_IOM_TX;
 				trans.bContinue = bContinue;
@@ -280,7 +263,7 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 #endif
 			}
 		}
-	} else {
+	} else { /* There's no data to send */
 		/* Set RX direction to receive data and release CS after transmission. */
 		trans.eDirection = AM_HAL_IOM_RX;
 		trans.bContinue = bContinue;


### PR DESCRIPTION
spi_context.h provides checks for ctx->rx_len and ctx->tx_len. Combine code for instruction length > 0.