### PR TITLE
drivers: mfd: Add ambiq iom binding file

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -149,21 +149,25 @@
 	status = "okay";
 };
 
-&spi0 {
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	status = "okay";
+&iom0 {
+	spi0: spi {
+		pinctrl-0 = <&spi0_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
+		clock-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	};
 };
 
-&i2c3 {
-	pinctrl-0 = <&i2c3_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio32_63 10 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio32_63 11 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
+&iom3 {
+	i2c3: i2c {
+		pinctrl-0 = <&i2c3_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio32_63 10 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio32_63 11 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+	};
 };
 
 &timer0 {

--- a/boards/ambiq/apollo3_evb/apollo3_evb_connector.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb_connector.dtsi
@@ -63,5 +63,5 @@
 	};
 };
 
-ambiq_spi0: &spi0 {};
-ambiq_i2c3: &i2c3 {};
+ambiq_spi0: &iom0 {};
+ambiq_i2c3: &iom3 {};

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -127,21 +127,25 @@
 	status = "okay";
 };
 
-&spi0 {
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	status = "okay";
+&iom0 {
+	spi0: spi {
+		pinctrl-0 = <&spi0_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
+		clock-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	};
 };
 
-&i2c3 {
-	pinctrl-0 = <&i2c3_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio32_63 10 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio32_63 11 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
+&iom3 {
+	i2c3: i2c {
+		pinctrl-0 = <&i2c3_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio32_63 10 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio32_63 11 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+	};
 };
 
 &timer0 {

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb_connector.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb_connector.dtsi
@@ -88,5 +88,5 @@
 	};
 };
 
-ambiq_spi0: &spi0 {};
-ambiq_i2c3: &i2c3 {};
+ambiq_spi0: &iom0 {};
+ambiq_i2c3: &iom3 {};

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -109,27 +109,33 @@
 	status = "okay";
 };
 
-&i2c0 {
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
+&iom0 {
+	i2c0: i2c {
+		pinctrl-0 = <&i2c0_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+	};
 };
 
-&spi1 {
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	status = "okay";
+&iom1 {
+	spi1: spi {
+		pinctrl-0 = <&spi1_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
+		clock-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	};
 };
 
-&spi4 {
-	pinctrl-0 = <&spi4_default>;
-	pinctrl-names = "default";
-	status = "okay";
+&iom4 {
+	spi4: spi {
+		pinctrl-0 = <&spi4_default>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };
 
 &mspi0 {

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
@@ -113,21 +113,25 @@
 	status = "okay";
 };
 
-&iom0_i2c {
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
+&iom0 {
+	i2c0: i2c {
+		pinctrl-0 = <&i2c0_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+	};
 };
 
-&iom1_spi {
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
-	clock-frequency = <1000000>;
-	status = "okay";
+&iom1 {
+	spi1: spi {
+		pinctrl-0 = <&spi1_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
+		clock-frequency = <1000000>;
+		status = "okay";
+	};
 };
 
 &flash0 {

--- a/boards/ambiq/apollo510_eb/apollo510_eb.dts
+++ b/boards/ambiq/apollo510_eb/apollo510_eb.dts
@@ -65,18 +65,20 @@
 	pinctrl-names = "default";
 };
 
-&i2c0 {
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
-	i2c_eeprom: eeprom@50 {
-		compatible = "fujitsu,mb85rcxx";
-		reg = <0x50>;
-		size = <DT_SIZE_K(128)>;
-		address-width = <16>;
+&iom0 {
+	i2c0: i2c {
+		pinctrl-0 = <&i2c0_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+		i2c_eeprom: eeprom@50 {
+			compatible = "fujitsu,mb85rcxx";
+			reg = <0x50>;
+			size = <DT_SIZE_K(128)>;
+			address-width = <16>;
+		};
 	};
 };
 

--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -121,21 +121,25 @@
 	status = "disabled";
 };
 
-&spi2 {
-	pinctrl-0 = <&spi2_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 29 GPIO_ACTIVE_LOW>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	status = "okay";
+&iom2 {
+	spi2: spi {
+		pinctrl-0 = <&spi2_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 29 GPIO_ACTIVE_LOW>;
+		clock-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	};
 };
 
-&i2c0 {
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
-	status = "okay";
+&iom0 {
+	i2c0: i2c {
+		pinctrl-0 = <&i2c0_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		scl-gpios = <&gpio0_31 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		sda-gpios = <&gpio0_31 6 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
+		status = "okay";
+	};
 };
 
 &uart0 {

--- a/boards/rakwireless/rak11720/rak11720.dts
+++ b/boards/rakwireless/rak11720/rak11720.dts
@@ -105,43 +105,49 @@
 	status = "okay";
 };
 
-&i2c2 {
-	compatible = "ambiq,i2c";
-	pinctrl-0 = <&i2c2_default>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	status = "okay";
+&iom2 {
+	i2c2: i2c {
+		compatible = "ambiq,i2c";
+		pinctrl-0 = <&i2c2_default>;
+		pinctrl-names = "default";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		status = "okay";
+	}
 };
 
-&spi0 {
-	compatible = "ambiq,spi";
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpio0_31 1 GPIO_ACTIVE_LOW>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	status = "okay";
+&iom0 {
+	spi0: spi {
+		compatible = "ambiq,spi";
+		pinctrl-0 = <&spi0_default>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio0_31 1 GPIO_ACTIVE_LOW>;
+		clock-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	}
 };
 
-&spi1 {
-	compatible = "ambiq,spi";
-	status = "okay";
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-names = "default";
-	clock-frequency = <DT_FREQ_M(1)>;
-	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
+&iom1 {
+	spi1: spi {
+		compatible = "ambiq,spi";
+		status = "okay";
+		pinctrl-0 = <&spi1_default>;
+		pinctrl-names = "default";
+		clock-frequency = <DT_FREQ_M(1)>;
+		cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
 
-	lora: lora@0 {
-		compatible = "semtech,sx1262";
-		reg = <0>;
-		reset-gpios = <&gpio0_31 17 GPIO_ACTIVE_LOW>;
-		busy-gpios = <&gpio0_31 16 GPIO_ACTIVE_HIGH>;
-		dio1-gpios = <&gpio0_31 15 GPIO_ACTIVE_HIGH>;
-		antenna-enable-gpios = <&gpio0_31 18 GPIO_ACTIVE_LOW>;
-		dio2-tx-enable;
-		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V3>;
-		tcxo-power-startup-delay-ms = <5>;
-		spi-max-frequency = <DT_FREQ_M(1)>;
-	};
+		lora: lora@0 {
+			compatible = "semtech,sx1262";
+			reg = <0>;
+			reset-gpios = <&gpio0_31 17 GPIO_ACTIVE_LOW>;
+			busy-gpios = <&gpio0_31 16 GPIO_ACTIVE_HIGH>;
+			dio1-gpios = <&gpio0_31 15 GPIO_ACTIVE_HIGH>;
+			antenna-enable-gpios = <&gpio0_31 18 GPIO_ACTIVE_LOW>;
+			dio2-tx-enable;
+			dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V3>;
+			tcxo-power-startup-delay-ms = <5>;
+			spi-max-frequency = <DT_FREQ_M(1)>;
+		};
+	}
 };
 
 &counter0 {

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -55,7 +55,7 @@ LOG_MODULE_REGISTER(bt_hci_driver);
 static uint8_t __noinit rxmsg[SPI_MAX_RX_MSG_LEN];
 
 static struct spi_dt_spec spi_bus =
-	SPI_DT_SPEC_INST_GET(0,
+	SPI_DT_SPEC_GET(DT_INST_PARENT(0),
 			     SPI_OP_MODE_MASTER | SPI_HALF_DUPLEX | SPI_TRANSFER_MSB |
 				     SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_WORD_SET(8),
 			     0);

--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -494,25 +494,27 @@ static int i2c_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static int pwr_on_ambiq_i2c_##n(void)                                                      \
 	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
+		uint32_t addr = DT_REG_ADDR(DT_PHANDLE(DT_INST_PARENT(n), ambiq_pwrcfg)) +         \
+				DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, offset);                   \
+		sys_write32((sys_read32(addr) | DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, mask)),    \
+			    addr);                                                                 \
 		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
 		return 0;                                                                          \
 	}                                                                                          \
 	static void i2c_irq_config_func_##n(void)                                                  \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), i2c_ambiq_isr,              \
-			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_INST_IRQN(n));                                                       \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),       \
+			    i2c_ambiq_isr, DEVICE_DT_INST_GET(n), 0);                              \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                            \
 	};                                                                                         \
 	static struct i2c_ambiq_data i2c_ambiq_data##n = {                                         \
 		.bus_sem = Z_SEM_INITIALIZER(i2c_ambiq_data##n.bus_sem, 1, 1),                     \
 		.transfer_sem = Z_SEM_INITIALIZER(i2c_ambiq_data##n.transfer_sem, 0, 1)};          \
 	static const struct i2c_ambiq_config i2c_ambiq_config##n = {                               \
-		.base = DT_INST_REG_ADDR(n),                                                       \
-		.size = DT_INST_REG_SIZE(n),                                                       \
-		.inst_idx = (DT_INST_REG_ADDR(n) - IOM0_BASE) / (IOM1_BASE - IOM0_BASE),           \
+		.base = DT_REG_ADDR(DT_INST_PARENT(n)),                                            \
+		.size = DT_REG_SIZE(DT_INST_PARENT(n)),                                            \
+		.inst_idx =                                                                        \
+			(DT_REG_ADDR(DT_INST_PARENT(n)) - IOM0_BASE) / (IOM1_BASE - IOM0_BASE),    \
 		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.irq_config_func = i2c_irq_config_func_##n,                                        \

--- a/drivers/spi/spi_ambiq_bleif.c
+++ b/drivers/spi/spi_ambiq_bleif.c
@@ -199,9 +199,10 @@ static int spi_ambiq_init(const struct device *dev)
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static int pwr_on_ambiq_spi_##n(void)                                                      \
 	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
+		uint32_t addr = DT_REG_ADDR(DT_PHANDLE(DT_INST_PARENT(n), ambiq_pwrcfg)) +         \
+				DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, offset);                   \
+		sys_write32((sys_read32(addr) | DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, mask)),    \
+			    addr);                                                                 \
 		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
 		return 0;                                                                          \
 	}                                                                                          \
@@ -209,8 +210,8 @@ static int spi_ambiq_init(const struct device *dev)
 		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),                                     \
 		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx)};                                    \
 	static const struct spi_ambiq_config spi_ambiq_config##n = {                               \
-		.base = DT_INST_REG_ADDR(n),                                                       \
-		.size = DT_INST_REG_SIZE(n),                                                       \
+		.base = DT_REG_ADDR(DT_INST_PARENT(n)),                                            \
+		.size = DT_REG_SIZE(DT_INST_PARENT(n)),                                            \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
 	SPI_DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, NULL, &spi_ambiq_data##n,                     \

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -572,26 +572,28 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static int pwr_on_ambiq_spi_##n(void)                                                      \
 	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
+		uint32_t addr = DT_REG_ADDR(DT_PHANDLE(DT_INST_PARENT(n), ambiq_pwrcfg)) +         \
+				DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, offset);                   \
+		sys_write32((sys_read32(addr) | DT_PHA(DT_INST_PARENT(n), ambiq_pwrcfg, mask)),    \
+			    addr);                                                                 \
 		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
 		return 0;                                                                          \
 	}                                                                                          \
 	static void spi_irq_config_func_##n(void)                                                  \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), spi_ambiq_isr,              \
-			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_INST_IRQN(n));                                                       \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),       \
+			    spi_ambiq_isr, DEVICE_DT_INST_GET(n), 0);                              \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                            \
 	};                                                                                         \
 	static struct spi_ambiq_data spi_ambiq_data##n = {                                         \
 		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),                                     \
 		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx),                                     \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)};                             \
 	static const struct spi_ambiq_config spi_ambiq_config##n = {                               \
-		.base = DT_INST_REG_ADDR(n),                                                       \
-		.size = DT_INST_REG_SIZE(n),                                                       \
-		.inst_idx = (DT_INST_REG_ADDR(n) - IOM0_BASE) / (IOM1_BASE - IOM0_BASE),           \
+		.base = DT_REG_ADDR(DT_INST_PARENT(n)),                                            \
+		.size = DT_REG_SIZE(DT_INST_PARENT(n)),                                            \
+		.inst_idx =                                                                        \
+			(DT_REG_ADDR(DT_INST_PARENT(n)) - IOM0_BASE) / (IOM1_BASE - IOM0_BASE),    \
 		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.irq_config_func = spi_irq_config_func_##n,                                        \

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -273,136 +273,136 @@
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spi0: spi@50004000 {
-			compatible = "ambiq,spi";
+		iom0: iom@50004000 {
+			compatible = "ambiq,iom";
 			reg = <0x50004000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <6 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi1: spi@50005000 {
-			compatible = "ambiq,spi";
+		iom1: iom@50005000 {
+			compatible = "ambiq,iom";
 			reg = <0x50005000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <7 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi2: spi@50006000 {
-			compatible = "ambiq,spi";
+		iom2: iom@50006000 {
+			compatible = "ambiq,iom";
 			reg = <0x50006000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <8 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi3: spi@50007000 {
-			compatible = "ambiq,spi";
+		iom3: iom@50007000 {
+			compatible = "ambiq,iom";
 			reg = <0x50007000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <9 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi4: spi@50008000 {
-			compatible = "ambiq,spi";
+		iom4: iom@50008000 {
+			compatible = "ambiq,iom";
 			reg = <0x50008000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <10 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi5: spi@50009000 {
-			compatible = "ambiq,spi";
+		iom5: iom@50009000 {
+			compatible = "ambiq,iom";
 			reg = <0x50009000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <11 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
-			zephyr,pm-device-runtime-auto;
-		};
 
-		i2c0: i2c@50004000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50004000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <6 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c1: i2c@50005000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50005000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <7 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c2: i2c@50006000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50006000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <8 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c3: i2c@50007000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50007000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <9 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c4: i2c@50008000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50008000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <10 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c5: i2c@50009000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50009000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <11 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
-			zephyr,pm-device-runtime-auto;
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
 		adc0: adc@50010000 {

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -291,136 +291,136 @@
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spi0: spi@50004000 {
-			compatible = "ambiq,spi";
+		iom0: iom@50004000 {
+			compatible = "ambiq,iom";
 			reg = <0x50004000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <6 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi1: spi@50005000 {
-			compatible = "ambiq,spi";
+		iom1: iom@50005000 {
+			compatible = "ambiq,iom";
 			reg = <0x50005000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <7 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi2: spi@50006000 {
-			compatible = "ambiq,spi";
+		iom2: iom@50006000 {
+			compatible = "ambiq,iom";
 			reg = <0x50006000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <8 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi3: spi@50007000 {
-			compatible = "ambiq,spi";
+		iom3: iom@50007000 {
+			compatible = "ambiq,iom";
 			reg = <0x50007000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <9 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi4: spi@50008000 {
-			compatible = "ambiq,spi";
+		iom4: iom@50008000 {
+			compatible = "ambiq,iom";
 			reg = <0x50008000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <10 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi5: spi@50009000 {
-			compatible = "ambiq,spi";
+		iom5: iom@50009000 {
+			compatible = "ambiq,iom";
 			reg = <0x50009000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <11 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
-			zephyr,pm-device-runtime-auto;
-		};
 
-		i2c0: i2c@50004000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50004000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <6 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c1: i2c@50005000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50005000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <7 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c2: i2c@50006000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50006000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <8 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c3: i2c@50007000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50007000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <9 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c4: i2c@50008000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50008000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <10 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c5: i2c@50009000 {
-			compatible = "ambiq,i2c";
-			reg = <0x50009000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <11 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
-			zephyr,pm-device-runtime-auto;
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
 		adc0: adc@50010000 {

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -436,164 +436,180 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x1000>;
 		};
 
-		iom0_spi: spi@40050000 {
-			compatible = "ambiq,spi";
+		iom0: iom@40050000 {
+			compatible = "ambiq,iom";
 			reg = <0x40050000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <6 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom0_i2c: i2c@40050000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40050000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <6 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
-		};
-
-		iom1_spi: spi@40051000 {
-			compatible = "ambiq,spi";
+		iom1: iom@40051000 {
+			compatible = "ambiq,iom";
 			reg = <0x40051000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <7 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom1_i2c: i2c@40051000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40051000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <7 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
-		};
-
-		iom2_spi: spi@40052000 {
-			compatible = "ambiq,spi";
+		iom2: iom@40052000 {
+			compatible = "ambiq,iom";
 			reg = <0x40052000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <8 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom2_i2c: i2c@40052000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40052000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <8 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
-		};
-
-		iom3_spi: spi@40053000 {
-			compatible = "ambiq,spi";
+		iom3: iom@40053000 {
+			compatible = "ambiq,iom";
 			reg = <0x40053000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <9 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom3_i2c: i2c@40053000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40053000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <9 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
-		};
-
-		iom4_spi: spi@40054000 {
-			compatible = "ambiq,spi";
+		iom4: iom@40054000 {
+			compatible = "ambiq,iom";
 			reg = <0x40054000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <10 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom4_i2c: i2c@40054000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40054000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <10 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
-		};
-
-		iom5_spi: spi@40055000 {
-			compatible = "ambiq,spi";
+		iom5: iom@40055000 {
+			compatible = "ambiq,iom";
 			reg = <0x40055000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <11 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom5_i2c: i2c@40055000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40055000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <11 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
-		};
-
-		iom6_spi: spi@40056000 {
-			compatible = "ambiq,spi";
+		iom6: iom@40056000 {
+			compatible = "ambiq,iom";
 			reg = <0x40056000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <12 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		iom6_i2c: i2c@40056000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40056000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <12 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
-		};
-
-		iom7_spi: spi@40057000 {
-			compatible = "ambiq,spi";
+		iom7: iom@40057000 {
+			compatible = "ambiq,iom";
 			reg = <0x40057000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <13 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
-		};
 
-		iom7_i2c: i2c@40057000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40057000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <13 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
 		adc0: adc@40038000 {

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -428,176 +428,184 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x1000>;
 		};
 
-		spi0: spi@40050000 {
-			compatible = "ambiq,spi";
+		iom0: iom@40050000 {
+			compatible = "ambiq,iom";
 			reg = <0x40050000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <6 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
-		};
 
-		spi1: spi@40051000 {
-			compatible = "ambiq,spi";
-			reg = <0x40051000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <7 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
-		};
-
-		spi2: spi@40052000 {
-			compatible = "ambiq,spi";
-			reg = <0x40052000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <8 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
-		};
-
-		spi3: spi@40053000 {
-			compatible = "ambiq,spi";
-			reg = <0x40053000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <9 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
-		};
-
-		spi4: spi@40054000 {
-			/* IOM4 works as SPI and is wired internally for BLE HCI. */
-			compatible = "ambiq,spi";
-			reg = <0x40054000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <10 0>;
-			cs-gpios = <&gpio32_63 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-			clock-frequency = <DT_FREQ_M(24)>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
-
-			bt_hci_apollo: bt-hci@0 {
-				compatible = "ambiq,bt-hci-spi";
-				reg = <0>;
-				spi-max-frequency = <DT_FREQ_M(24)>;
-				irq-gpios = <&gpio32_63 21 GPIO_ACTIVE_HIGH>;
-				reset-gpios = <&gpio32_63 23 GPIO_ACTIVE_LOW>;
-				clkreq-gpios = <&gpio32_63 20 GPIO_ACTIVE_HIGH>;
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 		};
 
-		spi5: spi@40055000 {
-			compatible = "ambiq,spi";
-			reg = <0x40055000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <11 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
-		};
-
-		spi6: spi@40056000 {
-			compatible = "ambiq,spi";
-			reg = <0x40056000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <12 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
-		};
-
-		spi7: spi@40057000 {
-			compatible = "ambiq,spi";
-			reg = <0x40057000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <13 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
-		};
-
-		i2c0: i2c@40050000 {
-			compatible = "ambiq,i2c";
-			reg = <0x40050000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <6 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
-		};
-
-		i2c1: i2c@40051000 {
-			compatible = "ambiq,i2c";
+		iom1: iom@40051000 {
+			compatible = "ambiq,iom";
 			reg = <0x40051000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <7 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		i2c2: i2c@40052000 {
-			compatible = "ambiq,i2c";
+		iom2: iom@40052000 {
+			compatible = "ambiq,iom";
 			reg = <0x40052000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <8 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		i2c3: i2c@40053000 {
-			compatible = "ambiq,i2c";
+		iom3: iom@40053000 {
+			compatible = "ambiq,iom";
 			reg = <0x40053000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <9 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		i2c4: i2c@40054000 {
-			compatible = "ambiq,i2c";
+		iom4: iom@40054000 {
+			compatible = "ambiq,iom";
 			reg = <0x40054000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <10 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
+			/* IOM4 works as SPI and is wired internally for BLE HCI. */
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				cs-gpios = <&gpio32_63 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+				clock-frequency = <DT_FREQ_M(24)>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+
+				bt_hci_apollo: bt-hci@0 {
+					compatible = "ambiq,bt-hci-spi";
+					reg = <0>;
+					spi-max-frequency = <DT_FREQ_M(24)>;
+					irq-gpios = <&gpio32_63 21 GPIO_ACTIVE_HIGH>;
+					reset-gpios = <&gpio32_63 23 GPIO_ACTIVE_LOW>;
+					clkreq-gpios = <&gpio32_63 20 GPIO_ACTIVE_HIGH>;
+				};
+			};
 		};
 
-		i2c5: i2c@40055000 {
-			compatible = "ambiq,i2c";
+		iom5: iom@40055000 {
+			compatible = "ambiq,iom";
 			reg = <0x40055000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <11 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		i2c6: i2c@40056000 {
-			compatible = "ambiq,i2c";
+		iom6: iom@40056000 {
+			compatible = "ambiq,iom";
 			reg = <0x40056000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <12 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		i2c7: i2c@40057000 {
-			compatible = "ambiq,i2c";
+		iom7: iom@40057000 {
+			compatible = "ambiq,iom";
 			reg = <0x40057000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <13 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
 		adc0: adc@40038000 {
@@ -658,14 +666,6 @@
 			maximum-speed = "full-speed";
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x400000>;
-		};
-
-		rtc0: rtc@40004800 {
-			compatible = "ambiq,rtc";
-			reg = <0x40004800 0x210>;
-			interrupts = <2 0>;
-			alarms-count = <1>;
-			status = "disabled";
 		};
 
 		pinctrl: pin-controller@40010000 {

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -455,180 +455,180 @@
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spi0: spi@IOM0_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom0: iom@IOM0_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM0_REG_BASE IOM0_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <6 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi1: spi@IOM1_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom1: iom@IOM1_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM1_REG_BASE IOM1_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <7 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi2: spi@IOM2_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom2: iom@IOM2_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM2_REG_BASE IOM2_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <8 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi3: spi@IOM3_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom3: iom@IOM3_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM3_REG_BASE IOM3_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <9 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi4: spi@IOM4_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom4: iom@IOM4_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM4_REG_BASE IOM4_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <10 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi5: spi@IOM5_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom5: iom@IOM5_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM5_REG_BASE IOM5_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <11 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi6: spi@IOM6_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom6: iom@IOM6_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM6_REG_BASE IOM6_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <12 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
-			zephyr,pm-device-runtime-auto;
+
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
-		spi7: spi@IOM7_BASE_NAME {
-			compatible = "ambiq,spi";
+		iom7: iom@IOM7_BASE_NAME {
+			compatible = "ambiq,iom";
 			reg = <IOM7_REG_BASE IOM7_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			interrupts = <13 0>;
-			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
-			zephyr,pm-device-runtime-auto;
-		};
 
-		i2c0: i2c@IOM0_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM0_REG_BASE IOM0_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <6 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c1: i2c@IOM1_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM1_REG_BASE IOM1_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <7 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c2: i2c@IOM2_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM2_REG_BASE IOM2_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <8 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c3: i2c@IOM3_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM3_REG_BASE IOM3_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <9 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c4: i2c@IOM4_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM4_REG_BASE IOM4_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <10 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c5: i2c@IOM5_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM5_REG_BASE IOM5_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <11 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c6: i2c@IOM6_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM6_REG_BASE IOM6_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <12 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
-			zephyr,pm-device-runtime-auto;
-		};
-
-		i2c7: i2c@IOM7_BASE_NAME {
-			compatible = "ambiq,i2c";
-			reg = <IOM7_REG_BASE IOM7_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <13 0>;
-			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
-			zephyr,pm-device-runtime-auto;
+			spi {
+				compatible = "ambiq,spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
+			i2c {
+				compatible = "ambiq,i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+				zephyr,pm-device-runtime-auto;
+			};
 		};
 
 		uart0: uart@UART0_BASE_NAME {

--- a/dts/bindings/i2c/ambiq,i2c.yaml
+++ b/dts/bindings/i2c/ambiq,i2c.yaml
@@ -5,18 +5,9 @@ description: Ambiq I2C
 
 compatible: "ambiq,i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml]
 
 properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
-
-  ambiq,pwrcfg:
-    required: true
-
   scl-gpios:
     type: phandle-array
     description: |

--- a/dts/bindings/mfd/ambiq,iom.yaml
+++ b/dts/bindings/mfd/ambiq,iom.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Ambiq Micro Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq SPI/I2C controller common properties
+
+compatible: "ambiq,iom"
+
+include: [base.yaml, ambiq-pwrcfg.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  ambiq,pwrcfg:
+    required: true

--- a/dts/bindings/spi/ambiq,spi.yaml
+++ b/dts/bindings/spi/ambiq,spi.yaml
@@ -5,17 +5,4 @@ description: Ambiq SPI
 
 compatible: "ambiq,spi"
 
-include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
-
-properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
-
-  clock-frequency:
-    required: true
-
-  ambiq,pwrcfg:
-    required: true
+include: [spi-controller.yaml, pinctrl-device.yaml]


### PR DESCRIPTION
This commit adds ambiq iom binding file to consolidate spi and i2c that share the same IO Master module on Apollo MCUs