### PR TITLE
dts: arm: ambiq: update dtsi

### DIFF
--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -593,7 +593,6 @@
 			internal-vref-mv = <1190>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2000>;
 		};
 
 		mspi0: spi@40060000 {
@@ -637,14 +636,6 @@
 			interrupts = <27 0>;
 			num-bidir-endpoints = <6>;
 			maximum-speed = "full-speed";
-			status = "disabled";
-		};
-
-		rtc0: rtc@40004800 {
-			compatible = "ambiq,rtc";
-			reg = <0x40004800 0x210>;
-			interrupts = <2 0>;
-			alarms-count = <1>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This commit fixes errors in the dtsi file after udpates to the adc yaml file. This driver also contained 2 rtc0.