### PR TITLE
Apollo510 nemasdk support

### DIFF
--- a/modules/hal_ambiq/Kconfig.components
+++ b/modules/hal_ambiq/Kconfig.components
@@ -8,3 +8,36 @@ config AMBIQ_COMPONENT_USE_BT
 	depends on SOC_AMBIQ_BT_SUPPORTED
 	help
 	  Use Bluetooth component from Ambiq
+
+config AMBIQ_COMPONENT_USE_NEMASDK
+	bool
+
+if AMBIQ_COMPONENT_USE_NEMASDK
+
+config MAX_PENDING_COMMAND_LIST
+	int "max value for pending command list"
+	default 100
+	range 10 200
+
+config GRAPHICS_HEAP_SIZE
+	int "graphics heap size, unit:KB"
+	default 1024
+	depends on !MEM_ATTR_HEAP
+
+config GPU_WAIT_IRQ_TIMEOUT_MS
+	int "timeout value to wait for GPU complete IRQ, unit: ms"
+	default 500
+
+config DC_WAIT_VSYNC_TIMEOUT_MS
+	int "timeout value to wait for DC VSYNC IRQ, unit: ms"
+	default 500
+
+module = NEMAGFX
+module-str = nemagfx
+source "subsys/logging/Kconfig.template.log_config"
+
+module = NEMADC
+module-str = nemadc
+source "subsys/logging/Kconfig.template.log_config"
+
+endif #AMBIQ_COMPONENT_USE_NEMASDK

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
     - name: ambiqhal_ambiq
       remote: github_ambiqmicro
       path: modules/hal/ambiq
-      revision: f1796b0ee52b998a9d15db765a8a9ce92364fbea
+      revision: 4e7d42766d5af90810c9cea5d774970c17d5ac14
       groups:
         - hal
     - name: hal_atmel


### PR DESCRIPTION
1.  NemaSDK component Kconfig option

Add AMBIQ_COMPONENT_USE_NEMASDK and related symbols to
modules/hal_ambiq/Kconfig.components so applications can enable Ambiq’s
NemaSDK GPU acceleration library from Kconfig.

2update hal_ambiq revision

Bump the hal_ambiq module to commit 4e7d42, which contains the
pre-built NemaSDK binaries and public headers required to use NemaSDK.
