### PR TITLE
samples: subsys: usb: mass: add eMMC support for USB mass storage

### DIFF
--- a/samples/subsys/usb/mass/Kconfig
+++ b/samples/subsys/usb/mass/Kconfig
@@ -40,12 +40,19 @@ config APP_MSC_STORAGE_SDCARD
 	imply FILE_SYSTEM
 	imply FAT_FILESYSTEM_ELM
 
+config APP_MSC_STORAGE_EMMC
+	bool "Use eMMC and FAT file system"
+	imply DISK_DRIVER_MMC
+	imply FILE_SYSTEM
+	imply FAT_FILESYSTEM_ELM
+
 endchoice
 
 config MASS_STORAGE_DISK_NAME
 	default "NAND" if DISK_DRIVER_FLASH
 	default "RAM" if DISK_DRIVER_RAM
 	default "SD" if DISK_DRIVER_SDMMC
+	default "SD2" if DISK_DRIVER_MMC
 
 if DISK_DRIVER_FLASH
 

--- a/samples/subsys/usb/mass/boards/apollo510_eb.conf
+++ b/samples/subsys/usb/mass/boards/apollo510_eb.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_MMC_DDR50=y
+CONFIG_MMC_CARD_8BIT_WIDTH=y

--- a/samples/subsys/usb/mass/boards/apollo510_eb.overlay
+++ b/samples/subsys/usb/mass/boards/apollo510_eb.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sdio0 {
+	status = "okay";
+	mmc {
+		status = "okay";
+	};
+};

--- a/samples/subsys/usb/mass/boards/apollo510_evb.conf
+++ b/samples/subsys/usb/mass/boards/apollo510_evb.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_MMC_DDR50=y
+CONFIG_MMC_CARD_8BIT_WIDTH=y

--- a/samples/subsys/usb/mass/boards/apollo510_evb.overlay
+++ b/samples/subsys/usb/mass/boards/apollo510_evb.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sdio0 {
+	status = "okay";
+	mmc {
+		status = "okay";
+	};
+};

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -114,3 +114,26 @@ tests:
       regex:
         - "End of files"
         - "The device is put in USB mass storage mode"
+  sample.usb_device_next.mass_emmc_fatfs:
+    min_ram: 32
+    filter: dt_compat_enabled("zephyr,mmc-disk")
+    platform_allow:
+      - apollo510_evb
+      - apollo510_eb
+    modules:
+      - fatfs
+    depends_on:
+      - usbd
+      - sdhc
+    extra_configs:
+      - CONFIG_APP_MSC_STORAGE_EMMC=y
+    tags:
+      - usb
+    harness: console
+    harness_config:
+      fixture: fixture_sdcard
+      type: multi_line
+      ordered: true
+      regex:
+        - "End of files"
+        - "The device is put in USB mass storage mode."

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -31,7 +31,8 @@ FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 
 #if !defined(CONFIG_DISK_DRIVER_FLASH) && \
 	!defined(CONFIG_DISK_DRIVER_RAM) && \
-	!defined(CONFIG_DISK_DRIVER_SDMMC)
+	!defined(CONFIG_DISK_DRIVER_SDMMC) && \
+	!defined(CONFIG_DISK_DRIVER_MMC)
 #error No supported disk driver enabled
 #endif
 
@@ -52,6 +53,10 @@ USBD_DEFINE_MSC_LUN(nand, "NAND", "Zephyr", "FlashDisk", "0.00");
 
 #if CONFIG_DISK_DRIVER_SDMMC
 USBD_DEFINE_MSC_LUN(sd, "SD", "Zephyr", "SD", "0.00");
+#endif
+
+#if CONFIG_DISK_DRIVER_MMC
+USBD_DEFINE_MSC_LUN(emmc, "SD2", "Zephyr", "eMMC", "0.00");
 #endif
 
 static int setup_flash(struct fs_mount_t *mnt)
@@ -95,6 +100,8 @@ static int mount_app_fs(struct fs_mount_t *mnt)
 		mnt->mnt_point = "/RAM:";
 	} else if (IS_ENABLED(CONFIG_DISK_DRIVER_SDMMC)) {
 		mnt->mnt_point = "/SD:";
+	} else if (IS_ENABLED(CONFIG_DISK_DRIVER_MMC)) {
+		mnt->mnt_point = "/SD2:";
 	} else {
 		mnt->mnt_point = "/NAND:";
 	}


### PR DESCRIPTION
Add a new configuration option for eMMC storage in Kconfig. Updated sample.yaml to include tests for eMMC with FAT file system. Added board configuration and overlay files for apollo510_evb to enable eMMC support.