### PR TITLE
pm: ambiq: remove unnecessary CONFIG_PM checks

### DIFF
--- a/drivers/audio/amic_ambiq_audadc.c
+++ b/drivers/audio/amic_ambiq_audadc.c
@@ -54,27 +54,23 @@ struct amic_ambiq_audadc_cfg {
 
 static void amic_ambiq_audadc_pm_policy_state_lock_get(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct amic_ambiq_audadc_data *data = dev->data;
+	struct amic_ambiq_audadc_data *data = dev->data;
 
-		if (!data->pm_policy_state_on) {
-			data->pm_policy_state_on = true;
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-			pm_device_runtime_get(dev);
-		}
+	if (!data->pm_policy_state_on) {
+		data->pm_policy_state_on = true;
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_device_runtime_get(dev);
 	}
 }
 
 static void amic_ambiq_audadc_pm_policy_state_lock_put(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct amic_ambiq_audadc_data *data = dev->data;
+	struct amic_ambiq_audadc_data *data = dev->data;
 
-		if (data->pm_policy_state_on) {
-			data->pm_policy_state_on = false;
-			pm_device_runtime_put(dev);
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-		}
+	if (data->pm_policy_state_on) {
+		data->pm_policy_state_on = false;
+		pm_device_runtime_put(dev);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
 }
 

--- a/drivers/audio/dmic_ambiq_pdm.c
+++ b/drivers/audio/dmic_ambiq_pdm.c
@@ -45,27 +45,23 @@ struct dmic_ambiq_pdm_cfg {
 
 static void dmic_ambiq_pdm_pm_policy_state_lock_get(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct dmic_ambiq_pdm_data *data = dev->data;
+	struct dmic_ambiq_pdm_data *data = dev->data;
 
-		if (!data->pm_policy_state_on) {
-			data->pm_policy_state_on = true;
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-			pm_device_runtime_get(dev);
-		}
+	if (!data->pm_policy_state_on) {
+		data->pm_policy_state_on = true;
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_device_runtime_get(dev);
 	}
 }
 
 static void dmic_ambiq_pdm_pm_policy_state_lock_put(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct dmic_ambiq_pdm_data *data = dev->data;
+	struct dmic_ambiq_pdm_data *data = dev->data;
 
-		if (data->pm_policy_state_on) {
-			data->pm_policy_state_on = false;
-			pm_device_runtime_put(dev);
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-		}
+	if (data->pm_policy_state_on) {
+		data->pm_policy_state_on = false;
+		pm_device_runtime_put(dev);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
 }
 

--- a/drivers/i2s/i2s_ambiq.c
+++ b/drivers/i2s/i2s_ambiq.c
@@ -51,27 +51,23 @@ struct i2s_ambiq_cfg {
 
 static void i2s_ambiq_pm_policy_state_lock_get(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct i2s_ambiq_data *data = dev->data;
+	struct i2s_ambiq_data *data = dev->data;
 
-		if (!data->pm_policy_state_on) {
-			data->pm_policy_state_on = true;
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-			pm_device_runtime_get(dev);
-		}
+	if (!data->pm_policy_state_on) {
+		data->pm_policy_state_on = true;
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_device_runtime_get(dev);
 	}
 }
 
 static void i2s_ambiq_pm_policy_state_lock_put(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct i2s_ambiq_data *data = dev->data;
+	struct i2s_ambiq_data *data = dev->data;
 
-		if (data->pm_policy_state_on) {
-			data->pm_policy_state_on = false;
-			pm_device_runtime_put(dev);
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-		}
+	if (data->pm_policy_state_on) {
+		data->pm_policy_state_on = false;
+		pm_device_runtime_put(dev);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
 }
 

--- a/drivers/serial/uart_ambiq.c
+++ b/drivers/serial/uart_ambiq.c
@@ -90,40 +90,32 @@ struct uart_ambiq_data {
 
 static void uart_ambiq_pm_policy_state_lock_get_unconditional(void)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-	}
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 }
 
 static void uart_ambiq_pm_policy_state_lock_get(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct uart_ambiq_data *data = dev->data;
+	struct uart_ambiq_data *data = dev->data;
 
-		if (!data->pm_policy_state_on) {
-			data->pm_policy_state_on = true;
-			uart_ambiq_pm_policy_state_lock_get_unconditional();
-		}
+	if (!data->pm_policy_state_on) {
+		data->pm_policy_state_on = true;
+		uart_ambiq_pm_policy_state_lock_get_unconditional();
 	}
 }
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 static void uart_ambiq_pm_policy_state_lock_put_unconditional(void)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-	}
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 }
 
 static void uart_ambiq_pm_policy_state_lock_put(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct uart_ambiq_data *data = dev->data;
+	struct uart_ambiq_data *data = dev->data;
 
-		if (data->pm_policy_state_on) {
-			data->pm_policy_state_on = false;
-			uart_ambiq_pm_policy_state_lock_put_unconditional();
-		}
+	if (data->pm_policy_state_on) {
+		data->pm_policy_state_on = false;
+		uart_ambiq_pm_policy_state_lock_put_unconditional();
 	}
 }
 #endif

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -49,27 +49,23 @@ typedef void (*spi_context_update_trx)(struct spi_context *ctx, uint8_t dfs, uin
 
 static void spi_ambiq_pm_policy_state_lock_get(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct spi_ambiq_data *data = dev->data;
+	struct spi_ambiq_data *data = dev->data;
 
-		if (!data->pm_policy_state_on) {
-			data->pm_policy_state_on = true;
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-			pm_device_runtime_get(dev);
-		}
+	if (!data->pm_policy_state_on) {
+		data->pm_policy_state_on = true;
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_device_runtime_get(dev);
 	}
 }
 
 static void spi_ambiq_pm_policy_state_lock_put(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_PM)) {
-		struct spi_ambiq_data *data = dev->data;
+	struct spi_ambiq_data *data = dev->data;
 
-		if (data->pm_policy_state_on) {
-			data->pm_policy_state_on = false;
-			pm_device_runtime_put(dev);
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-		}
+	if (data->pm_policy_state_on) {
+		data->pm_policy_state_on = false;
+		pm_device_runtime_put(dev);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
 }
 

--- a/soc/ambiq/apollo3x/soc.h
+++ b/soc/ambiq/apollo3x/soc.h
@@ -9,4 +9,15 @@
 
 #include <am_mcu_apollo.h>
 
+/* Return true if the buffer intersects the DTCM address range. */
+static inline bool ambiq_buf_in_dtcm(uintptr_t buf, size_t len_bytes)
+{
+	if (buf == 0 || len_bytes == 0) {
+		return false;
+	}
+
+	return ((buf <= (TCM_BASEADDR + TCM_MAX_SIZE - 1)) &&
+		((buf + len_bytes - 1) >= TCM_BASEADDR));
+}
+
 #endif /* __SOC_H__ */

--- a/soc/ambiq/apollo4x/soc.h
+++ b/soc/ambiq/apollo4x/soc.h
@@ -9,4 +9,14 @@
 
 #include <am_mcu_apollo.h>
 
+/* Return true if the buffer intersects the DTCM address range. */
+static inline bool ambiq_buf_in_dtcm(uintptr_t buf, size_t len_bytes)
+{
+	if (buf == 0 || len_bytes == 0) {
+		return false;
+	}
+	return ((buf <= (TCM_BASEADDR + TCM_MAX_SIZE - 1)) &&
+		((buf + len_bytes - 1) >= TCM_BASEADDR));
+}
+
 #endif /* __SOC_H__ */

--- a/soc/ambiq/apollo5x/soc.h
+++ b/soc/ambiq/apollo5x/soc.h
@@ -11,4 +11,14 @@
 
 bool buf_in_nocache(uintptr_t buf, size_t len_bytes);
 
+/* Return true if the buffer intersects the DTCM address range. */
+static inline bool ambiq_buf_in_dtcm(uintptr_t buf, size_t len_bytes)
+{
+	if (buf == 0 || len_bytes == 0) {
+		return false;
+	}
+	return ((buf <= (DTCM_BASEADDR + DTCM_MAX_SIZE - 1)) &&
+		((buf + len_bytes - 1) >= DTCM_BASEADDR));
+}
+
 #endif /* __SOC_H__ */


### PR DESCRIPTION
This commit removes unnecessary CONFIG_PM checks in ambiq drivers to prevent disabling PM_DEVICES APIs when disable CONFIG_PM.