### PR TITLE
hal: ambiq: release sdk5.2.0 updates

### DIFF
--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -636,12 +636,12 @@ static int ambiq_sdio_card_interrupt_enable(const struct device *dev, sdhc_inter
 	if (sources & SDHC_INT_SDIO) {
 		/* Enable SDIO Card Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_enable(data->host->pHandle,
-							    SDIO_INTSIG_CARDINTEN_Msk);
+							    SDIO0_INTSIG_CARDINTEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_enable(
-			data->host->pHandle, SDIO_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
@@ -650,12 +650,12 @@ static int ambiq_sdio_card_interrupt_enable(const struct device *dev, sdhc_inter
 	if (sources & SDHC_INT_INSERTED) {
 		/* Enable Card Insert Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_enable(data->host->pHandle,
-							    SDIO_INTSIG_CARDINSERTEN_Msk);
+							    SDIO0_INTSIG_CARDINSERTEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_enable(
-			data->host->pHandle, SDIO_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
@@ -664,12 +664,12 @@ static int ambiq_sdio_card_interrupt_enable(const struct device *dev, sdhc_inter
 	if (sources & SDHC_INT_REMOVED) {
 		/* Enable Card Removal Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_enable(data->host->pHandle,
-							    SDIO_INTSIG_CARDREMOVALEN_Msk);
+							    SDIO0_INTSIG_CARDREMOVALEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_enable(
-			data->host->pHandle, SDIO_INTENABLE_CARDREMOVALSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDREMOVALSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
@@ -692,12 +692,12 @@ static int ambiq_sdio_card_interrupt_disable(const struct device *dev, int sourc
 	if (sources & SDHC_INT_SDIO) {
 		/* Disable SDIO Card Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_disable(data->host->pHandle,
-							     SDIO_INTSIG_CARDINTEN_Msk);
+							     SDIO0_INTSIG_CARDINTEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_disable(
-			data->host->pHandle, SDIO_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
@@ -706,12 +706,12 @@ static int ambiq_sdio_card_interrupt_disable(const struct device *dev, int sourc
 	if (sources & SDHC_INT_INSERTED) {
 		/* Disable Card Insert Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_disable(data->host->pHandle,
-							     SDIO_INTSIG_CARDINSERTEN_Msk);
+							     SDIO0_INTSIG_CARDINSERTEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_disable(
-			data->host->pHandle, SDIO_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
@@ -720,12 +720,12 @@ static int ambiq_sdio_card_interrupt_disable(const struct device *dev, int sourc
 	if (sources & SDHC_INT_REMOVED) {
 		/* Disable Card Removal Interrupt */
 		ui32Status = am_hal_sdhc_intr_signal_disable(data->host->pHandle,
-							     SDIO_INTSIG_CARDREMOVALEN_Msk);
+							     SDIO0_INTSIG_CARDREMOVALEN_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}
 		ui32Status = am_hal_sdhc_intr_status_disable(
-			data->host->pHandle, SDIO_INTENABLE_CARDREMOVALSTATUSENABLE_Msk);
+			data->host->pHandle, SDIO0_INTENABLE_CARDREMOVALSTATUSENABLE_Msk);
 		if (ui32Status != AM_HAL_STATUS_SUCCESS) {
 			return -EIO;
 		}

--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: ambiqhal_ambiq
       remote: github_ambiqmicro
       path: modules/hal/ambiq
-      revision: a605224a8f8ed450c6e6514634b4dcda31b659ca
+      revision: 109318f1d24f1af0495033e06b67353be35274b5
       groups:
         - hal
     - name: babblesim_base


### PR DESCRIPTION
sdk5.2.0 updates
ADC: change VREF from 1.19V to 1.20V for Apollo510
ADC: add calibration with fKONST factor and overflow/underflow protection
ADC: update temperature sensor slope to 302.11
DSI: add am_hal_dsi_config() API supporting video and command modes
DSI: add RGB565/666/888 pixel format support
DSI: add video mode timing parameter configuration
USB: add automatic PHY clock configuration for 12MHz and 24MHz
USB: fix DMA transfer completion and ZLP handling
USB: simplify device speed query to use cached state
STIMER: fix compare delta timing for 3-cycle write latency
STIMER: update sentinel values to avoid stale interrupts
UART: use clock manager API to query SYSPLL frequency
UART: fix DMA busy flag handling in interrupt service
MCUCTRL: add am_hal_mcuctrl_trim_version_get() API
MCUCTRL: add HFXTAL aliases for EXTCLK32M macros
SYSPLL: update minimum FBDIV for integer mode from 4 to 10
Power: use power control API for crypto powerdown
SpotMgr: add compiler guards to avoid unsigned comparison warnings
Utils: add scanf support with am_util_stdio_scanf()
Utils: update delay functions to use platform-appropriate APIs