### PR TITLE
apollox_blue and peripheral AMOTA updates

### DIFF
--- a/drivers/bluetooth/hci/apollox_blue.c
+++ b/drivers/bluetooth/hci/apollox_blue.c
@@ -17,6 +17,9 @@
 #include <zephyr/drivers/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#if defined(CONFIG_REBOOT)
+#include <zephyr/sys/reboot.h>
+#endif
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -31,6 +34,8 @@ LOG_MODULE_REGISTER(bt_apollox_driver);
 #include "am_devices_cooper.h"
 #elif (CONFIG_SOC_SERIES_APOLLO3X)
 #include "am_apollo3_bt_support.h"
+#elif (CONFIG_SOC_SERIES_APOLLO5X)
+#include "am_devices_em9305.h"
 #endif /* CONFIG_SOC_SERIES_APOLLO4X */
 
 #define HCI_SPI_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(ambiq_bt_hci_spi)
@@ -55,44 +60,32 @@ LOG_MODULE_REGISTER(bt_apollox_driver);
 #define SPI_MAX_RX_MSG_LEN 258
 
 #if (CONFIG_SOC_SERIES_APOLLO5X)
-#define EM9305_STS_CHK_CNT_MAX         10       /* check EM9305 status cnt */
-#define WAIT_EM9305_RDY_TIMEOUT        12000    /* EM9305 timeout value.
-						 * Assume worst case cold start counter (1.2 sec)
-						 */
-#define EM9305_BUFFER_SIZE             259      /* Length of RX buffer */
-#define EM9305_SPI_HEADER_TX           0x42     /* SPI TX header byte */
-#define EM9305_SPI_HEADER_RX           0x81     /* SPI RX header byte */
-#define EM9305_STS1_READY_VALUE        0xC0     /* SPI Ready byte */
-
-uint8_t active_state_entered_evt[] = {0x04, 0xFF, 0x01, 0x01};
 static const struct gpio_dt_spec irq_gpio = GPIO_DT_SPEC_GET(HCI_SPI_NODE, irq_gpios);
 static const struct gpio_dt_spec rst_gpio = GPIO_DT_SPEC_GET(HCI_SPI_NODE, reset_gpios);
 static const struct gpio_dt_spec cs_gpio = GPIO_DT_SPEC_GET(SPI_DEV_NODE, cs_gpios);
 static const struct gpio_dt_spec cm_gpio = GPIO_DT_SPEC_GET(HCI_SPI_NODE, cm_gpios);
 
 static struct gpio_callback irq_gpio_cb;
-static bool spiTxInProgress;                    /* SPI lock when a transmission is in progress */
-static volatile bool Em9305status_ok;
-am_devices_em9305_callback_t g_Em9305cb;
-
-void am_devices_em9305_set_reset_state(bool data)
-{
-	gpio_pin_set_dt(&rst_gpio, data);
-}
-
-bool am_devices_em9305_get_reset_state(void)
-{
-	return gpio_pin_get_dt(&rst_gpio);
-}
 
 extern void bt_packet_irq_isr(const struct device *unused1, struct gpio_callback *unused2,
 			      uint32_t unused3);
 
+/* GPIO wrapper functions for EM9305 device driver */
 static bool irq_pin_state(void)
 {
-	int pin_state;
+	int pin_state = gpio_pin_get_dt(&irq_gpio);
 
-	pin_state = gpio_pin_get_dt(&irq_gpio);
+	return pin_state > 0;
+}
+
+static void bt_em9305_set_reset(bool state)
+{
+	gpio_pin_set_dt(&rst_gpio, state);
+}
+
+static bool bt_em9305_get_reset(void)
+{
+	int pin_state = gpio_pin_get_dt(&rst_gpio);
 
 	return pin_state > 0;
 }
@@ -107,144 +100,9 @@ static void bt_em9305_cs_release(void)
 	gpio_pin_set_dt(&cs_gpio, 0);
 }
 
-static void bt_em9305_wait_ready(void)
-{
-	uint16_t i;
-
-	for (i = 0; i < WAIT_EM9305_RDY_TIMEOUT; i++) {
-		if (irq_pin_state()) {
-			break;
-		}
-		k_busy_wait(100);
-	}
-
-	if (i >= WAIT_EM9305_RDY_TIMEOUT) {
-		LOG_WRN("EM9305 ready timeout after %d ms", WAIT_EM9305_RDY_TIMEOUT * 100 / 1000);
-	}
-}
-
-static uint8_t am_devices_em9305_tx_starts(bt_spi_transceive_fun transceive)
-{
-	uint8_t sCommand[2] = {EM9305_SPI_HEADER_TX, 0x00};
-	uint8_t sStas[2] = {0, 0};
-	uint8_t ret = 0;
-
-	/* Indicates that a SPI transfer is in progress */
-	spiTxInProgress = true;
-	/* Select the EM9305 */
-	bt_em9305_cs_set();
-	/* wait em9305 ready */
-	bt_em9305_wait_ready();
-	/* check ready again */
-
-	if (!irq_pin_state()) {
-		bt_em9305_cs_release();
-		spiTxInProgress = false;
-		LOG_ERR("wait em9305 ready timeout");
-		return ret;
-	}
-
-	for (uint32_t i = 0; i < EM9305_STS_CHK_CNT_MAX; i++) {
-		/* Select the EM9305 */
-		bt_em9305_cs_set();
-		ret = transceive(sCommand, 2, sStas, 2);
-		if (ret) {
-			LOG_ERR("%s: spi write error %d", __func__, ret);
-			return ret;
-		}
-
-		if (ret != AM_HAL_STATUS_SUCCESS) {
-			LOG_ERR("%s: ret =%d ", __func__, ret);
-			return 0;
-		}
-		/* Check if the EM9305 is ready and the rx buffer size is not zero. */
-		if ((sStas[0] == EM9305_STS1_READY_VALUE) && (sStas[1] != 0x00)) {
-			break;
-		}
-		bt_em9305_cs_release();
-	}
-
-	return sStas[1];
-}
-
-static void am_devices_em9305_tx_ends(void)
-{
-	/* Deselect the EM9305 */
-	bt_em9305_cs_release();
-	/* Indicates that the SPI transfer is finished */
-	spiTxInProgress = false;
-}
-
 int bt_apollo_spi_send(uint8_t *pui8Values, uint16_t ui32NumBytes, bt_spi_transceive_fun transceive)
 {
-	uint32_t ui32ErrorStatus = AM_DEVICES_EM9305_STATUS_SUCCESS;
-	int ret = -ENOTSUP;
-	uint8_t data[EM9305_BUFFER_SIZE];
-	uint8_t em9305BufSize = 0;
-
-	if (ui32NumBytes <= EM9305_BUFFER_SIZE) {
-		for (uint32_t i = 0; i < ui32NumBytes;) {
-			em9305BufSize = am_devices_em9305_tx_starts(transceive);
-
-			if (em9305BufSize == 0x00) {
-				ui32ErrorStatus = AM_DEVICES_EM9305_RX_FULL;
-				printf("EM9305_RX_FULL\r\n");
-				am_devices_em9305_tx_ends();
-				break;
-			}
-			uint32_t len = (em9305BufSize < (ui32NumBytes - i)) ? em9305BufSize
-									    : (ui32NumBytes - i);
-
-			/* check again if there is room to send more data */
-			if ((len > 0) && (em9305BufSize)) {
-				memcpy(data, pui8Values + i, len);
-				i += len;
-
-				/* Write to the IOM. */
-				/* Transmit the message */
-				ret = transceive(data, len, NULL, 0);
-
-				if (ret != AM_HAL_STATUS_SUCCESS) {
-					ui32ErrorStatus = AM_DEVICES_EM9305_DATA_TRANSFER_ERROR;
-					LOG_ERR("%s: ret= %d", __func__, ret);
-				}
-			}
-			am_devices_em9305_tx_ends();
-		}
-	} else {
-		ui32ErrorStatus = AM_DEVICES_EM9305_DATA_LENGTH_ERROR;
-		LOG_ERR("%s: error (STATUS ERROR) Packet Too Large", __func__);
-	}
-
-	return ui32ErrorStatus;
-}
-
-static void bt_em9305_controller_reset(void)
-{
-	/* Reset the controller*/
-	gpio_pin_set_dt(&rst_gpio, 0);
-	/* Take controller out of reset */
-	k_sleep(K_MSEC(2));
-	gpio_pin_set_dt(&rst_gpio, 1);
-	k_sleep(K_MSEC(2));
-	gpio_pin_set_dt(&rst_gpio, 0);
-}
-
-uint32_t am_devices_em9305_init(am_devices_em9305_callback_t *cb)
-{
-	if ((!cb) || (!cb->write) || (!cb->reset)) {
-		return AM_DEVICES_EM9305_STATUS_ERROR;
-	}
-	/* Register the callback functions */
-	g_Em9305cb.write = cb->write;
-	g_Em9305cb.reset = cb->reset;
-	g_Em9305cb.reset();
-	/* wait for 9305 activated status ok */
-	while (!Em9305status_ok) {
-		;
-	}
-
-	return AM_DEVICES_EM9305_STATUS_SUCCESS;
+	return am_devices_em9305_blocking_write(pui8Values, ui32NumBytes, transceive);
 }
 #endif /* CONFIG_SOC_SERIES_APOLLO5X */
 
@@ -342,6 +200,7 @@ int bt_apollo_spi_send(uint8_t *data, uint16_t len, bt_spi_transceive_fun transc
 	uint8_t command[1] = {SPI_WRITE};
 	uint8_t response[2] = {0, 0};
 	uint16_t fail_count = 0;
+	bool sent = false;
 
 	do {
 		/* Check if the controller is ready to receive the HCI packets. */
@@ -354,9 +213,15 @@ int bt_apollo_spi_send(uint8_t *data, uint16_t len, bt_spi_transceive_fun transc
 			if (ret) {
 				LOG_ERR("SPI write error %d", ret);
 			}
+			sent = (ret == 0);
 			break;
 		}
 	} while (fail_count++ < SPI_WRITE_TIMEOUT);
+
+	if (!sent && (ret == 0)) {
+		LOG_ERR("SPI write timeout waiting for controller ready");
+		ret = -ETIMEDOUT;
+	}
 #elif (CONFIG_SOC_SERIES_APOLLO3X)
 	ret = transceive(data, len, NULL, 0);
 	if ((ret) && (ret != AM_HAL_BLE_STATUS_SPI_NOT_READY)) {
@@ -379,7 +244,7 @@ int bt_apollo_spi_rcv(uint8_t *data, uint16_t *len, bt_spi_transceive_fun transc
 
 		*len = 0;
 		/* Check if the SPI is free */
-		if (spiTxInProgress) {
+		if (am_devices_em9305_get_spi_tx_status()) {
 			/* TX in progress -> Ignore RDY interrupt */
 			LOG_ERR("EM9305 SPI TX in progress");
 			return AM_DEVICES_EM9305_TX_BUSY;
@@ -516,15 +381,7 @@ bool bt_apollo_vnd_rcv_ongoing(uint8_t *data, uint16_t len)
 		return false;
 	}
 #elif (CONFIG_SOC_SERIES_APOLLO5X)
-	bool ret = false;
-
-	if (memcmp(data, active_state_entered_evt, sizeof(active_state_entered_evt)) == 0) {
-		printf("em9305 enter active state \r\n");
-		Em9305status_ok = true;
-		ret = true;
-	}
-
-	return ret;
+	return am_devices_em9305_check_active_state_event(data, len);
 #else
 	return false;
 #endif /* CONFIG_SOC_SERIES_APOLLO4X */
@@ -536,6 +393,10 @@ int bt_hci_transport_setup(const struct device *dev)
 	int ret = 0;
 
 #if (CONFIG_SOC_SERIES_APOLLO5X)
+	/* Register GPIO operations for EM9305 device driver */
+	am_devices_em9305_register_gpio_ops(bt_em9305_set_reset, bt_em9305_get_reset, irq_pin_state,
+					    bt_em9305_cs_set, bt_em9305_cs_release);
+
 	/* Configure RST pin and hold BLE in Reset */
 	ret = gpio_pin_configure_dt(&rst_gpio, GPIO_OUTPUT_ACTIVE);
 	if (ret) {
@@ -623,7 +484,7 @@ int bt_apollo_controller_init(spi_transmit_fun transmit)
 #if (CONFIG_SOC_SERIES_APOLLO5X)
 	am_devices_em9305_callback_t cb = {
 		.write = transmit,
-		.reset = bt_em9305_controller_reset,
+		.reset = am_devices_em9305_controller_reset,
 	};
 
 	/* Initialize the BLE controller */
@@ -643,6 +504,15 @@ int bt_apollo_controller_init(spi_transmit_fun transmit)
 	/* Initialize the BLE controller */
 	ret = am_devices_cooper_init(&cb);
 	if (ret == AM_DEVICES_COOPER_STATUS_SUCCESS) {
+		if (am_devices_cooper_upgrade_performed()) {
+#if defined(CONFIG_REBOOT)
+			LOG_INF("BLE controller update applied, rebooting host for clean restart");
+			sys_reboot(SYS_REBOOT_COLD);
+#else
+			LOG_INF("BLE controller update applied, continue to main application");
+#endif
+		}
+
 		am_devices_cooper_set_initialize_state(AM_DEVICES_COOPER_STATE_INITIALIZED);
 		LOG_INF("BT controller initialized");
 	} else {
@@ -667,7 +537,20 @@ int bt_apollo_controller_deinit(void)
 {
 	int ret = 0;
 
-#if (CONFIG_SOC_SERIES_APOLLO4X)
+#if (CONFIG_SOC_SERIES_APOLLO5X)
+	/* Deinitialize the BLE controller driver */
+	ret = am_devices_em9305_deinit();
+	if (ret == AM_DEVICES_EM9305_STATUS_SUCCESS) {
+		/* Disable GPIOs */
+		gpio_pin_configure_dt(&irq_gpio, GPIO_DISCONNECTED);
+		gpio_pin_configure_dt(&rst_gpio, GPIO_DISCONNECTED);
+		gpio_remove_callback(irq_gpio.port, &irq_gpio_cb);
+		LOG_INF("BT controller deinitialized");
+	} else {
+		ret = -EPERM;
+		LOG_ERR("BT controller deinitialization fails");
+	}
+#elif (CONFIG_SOC_SERIES_APOLLO4X)
 	/* Keep the Controller in resetting state */
 	gpio_pin_set_dt(&rst_gpio, 1);
 
@@ -693,7 +576,7 @@ int bt_apollo_controller_deinit(void)
 	}
 #else
 	ret = -ENOTSUP;
-#endif /* CONFIG_SOC_SERIES_APOLLO4X */
+#endif /* CONFIG_SOC_SERIES_APOLLO5X */
 
 	return ret;
 }

--- a/drivers/bluetooth/hci/apollox_blue.h
+++ b/drivers/bluetooth/hci/apollox_blue.h
@@ -15,42 +15,6 @@
 extern "C" {
 #endif
 
-enum EM9305_STATUS {
-
-	AM_DEVICES_EM9305_STATUS_SUCCESS = 0,
-	AM_DEVICES_EM9305_STATUS_ERROR,
-	AM_DEVICES_EM9305_STATUS_BUS_BUSY,
-	AM_DEVICES_EM9305_TX_BUSY,
-	AM_DEVICES_EM9305_NOT_READY,
-	AM_DEVICES_EM9305_NO_DATA_TX,
-	AM_DEVICES_EM9305_RX_FULL,
-	AM_DEVICES_EM9305_DATA_LENGTH_ERROR,
-	AM_DEVICES_EM9305_CMD_TRANSFER_ERROR,
-	AM_DEVICES_EM9305_DATA_TRANSFER_ERROR,
-	AM_DEVICES_EM9305_STATUS_INVALID_OPERATION
-};
-
-typedef struct {
-	/**
-	 *************************************************************************************
-	 * @brief Starts a data transmission via IOM
-	 *
-	 * @param[in]  data        Pointer to the TX buffer
-	 * @param[in]  size        Size of the transmission
-	 * @return                 Status of data transmission, 0 is success.
-	 *************************************************************************************
-	 */
-	int (*write)(uint8_t *data, uint16_t len);
-
-	/**
-	 *************************************************************************************
-	 * @brief Reset the BLE controller via RESET GPIO.
-	 *
-	 *************************************************************************************
-	 */
-	void (*reset)(void);
-} am_devices_em9305_callback_t;
-
 /**
  * @typedef bt_spi_transceive_fun
  * @brief SPI transceive function for Bluetooth packet.
@@ -146,13 +110,6 @@ bool bt_apollo_vnd_rcv_ongoing(uint8_t *data, uint16_t len);
  * for example, clear the interrupt status.
  */
 void bt_apollo_rcv_isr_preprocess(void);
-
-/**
- * @brief Check if the EM9305 is enabled.
- *
- * @return true indicates if the EM9305 is enabled.
- */
-bool bt_apollo_em9305_enabled(void);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/services/amota.h
+++ b/include/zephyr/bluetooth/services/amota.h
@@ -192,6 +192,13 @@ int bt_amota_notify(void);
  */
 int bt_amota_conn_init(struct bt_conn *conn);
 
+/** @brief Reset AMOTA transfer state when the link drops (call from disconnected callback).
+ *
+ * Clears the stored connection pointer and partial packet / flash buffer state so a
+ * later session does not inherit a broken OTA context.
+ */
+void bt_amota_conn_deinit(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/peripheral_amota/src/main.c
+++ b/samples/bluetooth/peripheral_amota/src/main.c
@@ -26,6 +26,38 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
+static int start_advertising(void)
+{
+	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+	} else {
+		printk("Advertising successfully started\n");
+	}
+
+	return err;
+}
+
+/*
+ * The host calls the disconnected callback from conn deferred_work before it
+ * releases the ACL connection object. With CONFIG_BT_MAX_CONN=1, starting
+ * connectable advertising synchronously in disconnected() then needs a new
+ * conn for BT_CONN_ADV_CONNECTABLE and hits -ENOMEM. Defer restart until after
+ * that work item returns and bt_conn_unref() runs.
+ */
+static void adv_restart_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	int err = start_advertising();
+
+	if (err == -ENOMEM) {
+		(void)k_work_reschedule(dwork, K_MSEC(50));
+	}
+}
+
+static K_WORK_DELAYABLE_DEFINE(adv_restart_work, adv_restart_work_handler);
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -38,7 +70,13 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(conn);
+
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
+
+	bt_amota_conn_deinit();
+
+	(void)k_work_reschedule(&adv_restart_work, K_NO_WAIT);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
@@ -48,17 +86,9 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static void bt_ready(void)
 {
-	int err;
-
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err) {
-		printk("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
+	(void)start_advertising();
 }
 
 static void auth_cancel(struct bt_conn *conn)

--- a/subsys/bluetooth/services/amota.c
+++ b/subsys/bluetooth/services/amota.c
@@ -29,11 +29,27 @@ LOG_MODULE_REGISTER(amota);
 #include "am_util_multi_boot.h"
 #include "am_hal_security.h"
 
+/*
+ * Clean the page buffer before programming. For read-back verify,
+ * invalidate D-cache so memcpy from MRAM sees programmed data.
+ */
+#if defined(CONFIG_SOC_APOLLO510B)
+static void amotas_dcache_clean_mram_src(const void *buf, uint32_t len)
+{
+	am_hal_cachectrl_range_t r = {
+		.ui32StartAddr = (uint32_t)buf,
+		.ui32Size = len,
+	};
+
+	(void)am_hal_cachectrl_dcache_clean(&r);
+}
+#endif
+
 /* If AM_HAL_FLASH_PAGE_SIZE is not defined (e.g., not set as compile definition),
  * define it based on the chip type
  */
 #ifndef AM_HAL_FLASH_PAGE_SIZE
-#if defined(AM_PART_APOLLO510) || defined(AM_PART_APOLLO4P)
+#if IS_ENABLED(CONFIG_SOC_SERIES_APOLLO4X) || IS_ENABLED(CONFIG_SOC_APOLLO510B)
 #define AM_HAL_FLASH_PAGE_SIZE 1024 /* MRAM uses 1KB pages */
 #else
 #define AM_HAL_FLASH_PAGE_SIZE 8192 /* Default flash page size */
@@ -51,18 +67,18 @@ LOG_MODULE_REGISTER(amota);
  * The app start address is corresponding to MCU_MRAM start address of app example
  * in linker_script file, which is:
  * - 0x00018000 for Apollo4P by default.
- * - 0x00410000 for Apollo510 and Apollo330P_510L by default.
+ * - 0x00410000 for Apollo510 by default.
  * ****************************************************************************
  */
 #define OTA_MAX_IMAGE_SIZE  (512 * 1024)
 #define OTA_DESCRIPTOR_SIZE AM_HAL_FLASH_PAGE_SIZE
-#if defined(AM_PART_APOLLO4P)
+#if IS_ENABLED(CONFIG_SOC_SERIES_APOLLO4X)
 #if defined(AM_HAL_MRAM_TOTAL_SIZE) && (OTA_MAX_IMAGE_SIZE > (AM_HAL_MRAM_TOTAL_SIZE - 0x18000) / 2)
 #error "OTA_MAX_IMAGE_SIZE is too large!"
 #endif
 #define OTA_POINTER_LOCATION        (0x00018000 + OTA_MAX_IMAGE_SIZE)
 #define AMOTA_INT_FLASH_OTA_ADDRESS (OTA_POINTER_LOCATION + OTA_DESCRIPTOR_SIZE)
-#elif defined(AM_PART_APOLLO510)
+#elif IS_ENABLED(CONFIG_SOC_APOLLO510B)
 #if defined(AM_HAL_MRAM_TOTAL_SIZE) && (OTA_MAX_IMAGE_SIZE > (AM_HAL_MRAM_TOTAL_SIZE - 0x10000) / 2)
 #error "OTA_MAX_IMAGE_SIZE is too large!"
 #endif
@@ -248,9 +264,9 @@ static int verify_flash_content(uint32_t flashAddr, uint32_t *pSram, uint32_t le
 	uint32_t offset = 0;
 	uint32_t remaining = len;
 	int ret = 0;
-#if defined(AM_PART_APOLLO510)
-	/* Clean the cache after writing and invalidate before reading */
-	am_hal_cachectrl_dcache_invalidate(NULL, true);
+#if defined(CONFIG_SOC_APOLLO510B)
+	/* Invalidate (and clean) D$ before reading MRAM for verify */
+	(void)am_hal_cachectrl_dcache_invalidate(NULL, true);
 #endif
 	while (remaining) {
 		uint32_t tmpSize = (remaining > AMOTA_PACKET_SIZE) ? AMOTA_PACKET_SIZE : remaining;
@@ -311,6 +327,10 @@ static bool amotas_write2flash(uint16_t len, uint8_t *buf, uint32_t addr, bool l
 		 */
 		if (lastPktFlag || (amotasFlash.bufferIndex == g_pFlash->flashPageSize)) {
 			ui32TargetAddress = (addr + ui8PageCount * g_pFlash->flashPageSize);
+#if defined(CONFIG_SOC_APOLLO510B)
+			amotas_dcache_clean_mram_src(amotasFlash.writeBuffer,
+						     g_pFlash->flashPageSize);
+#endif
 			/* Always write whole pages */
 			if ((g_pFlash->flash_write_page(ui32TargetAddress,
 							(uint32_t *)amotasFlash.writeBuffer,
@@ -319,6 +339,10 @@ static bool amotas_write2flash(uint16_t len, uint8_t *buf, uint32_t addr, bool l
 						  (uint32_t *)amotasFlash.writeBuffer,
 						  amotasFlash.bufferIndex, g_pFlash) != 0)) {
 				bResult = false;
+				/* Discard buffered page so the next FW_DATA uses a consistent
+				 * addr/index.
+				 */
+				amotasFlash.bufferIndex = 0;
 				break;
 			}
 			LOG_DBG("Flash write succeeded to address 0x%x. length %d",
@@ -401,7 +425,7 @@ void amotas_packet_handler(eAmotaCommand cmd, uint16_t len, uint8_t *buf)
 		amota.data.fwHeader.storageType = sys_get_le32(buf + 40);
 		amota.data.fwHeader.imageId = sys_get_le32(buf + 44);
 
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4P) || defined(AM_PART_APOLLO4L)
+#if IS_ENABLED(CONFIG_SOC_SERIES_APOLLO4X)
 		/* get the SBL OTA storage address if the image is for SBL
 		 * the address can be 0x8000 or 0x10000 based on current SBL running address
 		 */
@@ -680,8 +704,21 @@ int bt_amota_conn_init(struct bt_conn *conn)
 	LOG_INF("AMOTA: Connection initialized");
 	amota.data.state = AMOTA_STATE_INIT;
 	amota.conn = conn;
+	amotasFlash.bufferIndex = 0;
+	amota.data.pkt.offset = 0;
+	amota.data.pkt.len = 0;
+	amota.data.pkt.type = AMOTA_CMD_UNKNOWN;
 
 	return 0;
+}
+
+void bt_amota_conn_deinit(void)
+{
+	amota.conn = NULL;
+	amotasFlash.bufferIndex = 0;
+	amota.data.pkt.offset = 0;
+	amota.data.pkt.len = 0;
+	amota.data.pkt.type = AMOTA_CMD_UNKNOWN;
 }
 
 SYS_INIT(bt_amota_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: ambiqhal_ambiq
       remote: github_ambiqmicro
       path: modules/hal/ambiq
-      revision: ee0fbf2efb08d5e724e11a81acdb6c7956e47428
+      revision: 7157746221a4518837f9a54d1543e40de5cef706
       groups:
         - hal
     - name: babblesim_base


### PR DESCRIPTION
Move the EM9305 implementation into the Ambiq Bluetooth HAL so it
can be reused by other drivers.

Handle Cooper upgrade detection with optional cold reboot to ensure a
clean host/controller restart sequence.

Add connection deinit API and clear AMOTA transfer state on disconnect
and write-failure paths to avoid stale OTA context reuse.

Add Apollo MRAM cache maintenance hooks around program/verify operations
and update SoC handling for page-size/address behavior.

Update peripheral AMOTA sample to defer advertising restart from the
disconnect callback and retry safely under resource pressure.