### PR TITLE
drivers: mspi: ambiq: add timeout and k_yield to context lock spin loop

### DIFF
--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -256,9 +256,16 @@ static inline int mspi_context_lock(struct mspi_context          *ctx,
 		} else if (ctx->packets_left == 0) {
 			if (ctx->callback_ctx) {
 				volatile struct mspi_event_data *evt_data;
+				k_timepoint_t end = sys_timepoint_calc(
+					K_MSEC(xfer->timeout ? xfer->timeout
+						: CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE));
 
 				evt_data = &ctx->callback_ctx->mspi_evt.evt_data;
 				while (evt_data->status != 0) {
+					if (sys_timepoint_expired(end)) {
+						return -ETIMEDOUT;
+					}
+					k_yield();
 				}
 				ret = 1;
 			} else {

--- a/drivers/mspi/mspi_ambiq_ap4.c
+++ b/drivers/mspi/mspi_ambiq_ap4.c
@@ -394,9 +394,16 @@ static inline int mspi_context_lock(struct mspi_context          *ctx,
 		} else if (ctx->packets_left == 0) {
 			if (ctx->callback_ctx) {
 				volatile struct mspi_event_data *evt_data;
+				k_timepoint_t end = sys_timepoint_calc(
+					K_MSEC(xfer->timeout ? xfer->timeout
+						: CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE));
 
 				evt_data = &ctx->callback_ctx->mspi_evt.evt_data;
 				while (evt_data->status != 0) {
+					if (sys_timepoint_expired(end)) {
+						return -ETIMEDOUT;
+					}
+					k_yield();
 				}
 				ret = 1;
 			} else {

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -448,9 +448,16 @@ static inline int mspi_context_lock(struct mspi_context          *ctx,
 		} else if (ctx->packets_left == 0) {
 			if (ctx->callback_ctx) {
 				volatile struct mspi_event_data *evt_data;
+				k_timepoint_t end = sys_timepoint_calc(
+					K_MSEC(xfer->timeout ? xfer->timeout
+						: CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE));
 
 				evt_data = &ctx->callback_ctx->mspi_evt.evt_data;
 				while (evt_data->status != 0) {
+					if (sys_timepoint_expired(end)) {
+						return -ETIMEDOUT;
+					}
+					k_yield();
 				}
 				ret = 1;
 			} else {


### PR DESCRIPTION
Add a timeout and `k_yield()` call to the `mspi_context_lock` spin loop in the AP3, AP4, and AP5 MSPI drivers.

Previously the loop spun indefinitely on `evt_data->status != 0` with no yield, which could starve cooperative threads and had no way to detect a hung transfer.

Changes:
- Compute a deadline with `sys_timepoint_calc(K_MSEC(xfer->timeout))` before entering the spin loop
- Inside the loop, call `k_yield()` to allow other threads to run
- Return `-ETIMEDOUT` if the deadline expires before the event status clears

Affects: `drivers/mspi/mspi_ambiq_ap3.c`, `drivers/mspi/mspi_ambiq_ap4.c`, `drivers/mspi/mspi_ambiq_ap5.c`