### PR TITLE
boards: ambiq: apollo510b_evb: enable USB device + fix SDIO pinctrl

### DIFF
--- a/boards/ambiq/apollo510b_evb/apollo510b_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo510b_evb/apollo510b_evb-pinctrl.dtsi
@@ -322,18 +322,22 @@
 
 	sdio0_default: sdio0_default {
 		group0 {
-			pinmux = <SDIF0_DAT1_P85>,
-				 <SDIF0_DAT3_P87>,
-				 <SDIF0_DAT4_P156>,
+			pinmux = <SDIF0_DAT4_P156>,
 				 <SDIF0_DAT5_P157>,
 				 <SDIF0_DAT6_P158>,
 				 <SDIF0_DAT7_P159>;
 			drive-strength = "1.0";
 		};
 
+		/* DAT0..DAT3 and CMD need pull-ups so the eMMC can pull them
+		 * low without floating; without pull-ups on DAT1/DAT3 the
+		 * 8-bit eMMC CRC fails intermittently on multi-block writes.
+		 */
 		group1 {
 			pinmux = <SDIF0_DAT0_P84>,
+				 <SDIF0_DAT1_P85>,
 				 <SDIF0_DAT2_P86>,
+				 <SDIF0_DAT3_P87>,
 				 <SDIF0_CMD_P160>,
 				 <SDIF0_CLKOUT_P88>;
 			drive-strength = "1.0";

--- a/drivers/usb/udc/Kconfig.ambiq
+++ b/drivers/usb/udc/Kconfig.ambiq
@@ -8,7 +8,7 @@ config UDC_AMBIQ
 	select GPIO
 	select AMBIQ_HAL
 	select AMBIQ_HAL_USE_USB
-	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT if SOC_SERIES_APOLLO5X && !SOC_APOLLO510B
 	help
 	  Enable USB Device Controller Driver.
 

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -135,17 +135,6 @@ static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *bu
 	}
 	udc_ep_set_busy(ep_cfg, true);
 
-	/*
-	 * Make sure that OUT transaction size triggered doesn't exceed EP's MPS,
-	 * as the USB IP has no way to detect end on transaction when last packet
-	 * is not a short packet. Except for UDC_AMBIQ_DMA1_MODE, where such
-	 * detection is available.
-	 */
-	if (!IS_ENABLED(CONFIG_UDC_AMBIQ_DMA1_MODE) && (ep != USB_CONTROL_EP_OUT) &&
-	    (ep_cfg->mps < rx_size)) {
-		rx_size = ep_cfg->mps;
-	}
-
 	/* Cache management if cache and DMA is enabled */
 	if (!IS_ENABLED(CONFIG_UDC_AMBIQ_PIO_MODE) && (ep != USB_CONTROL_EP_OUT)) {
 		sys_cache_data_invd_range(buf->data, buf->size);


### PR DESCRIPTION
## Summary

Brings USB device-controller support on `apollo510b_evb` up to parity with
the `apollo510L-dev` branch, plus the SDIO pinctrl correction needed to bring
the board up and exercise USB mass storage. Backported from `apollo510L-dev`
commit e434acf9, split into focused, correctly-scoped commits.

## Changes

**USB (UDC driver)**
- `Kconfig.ambiq`: gate `UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT` on
  `SOC_SERIES_APOLLO5X && !SOC_APOLLO510B`, so Apollo510B operates full-speed
  only (matching its USB IP). Other Apollo5x parts keep high-speed.
- `udc_ambiq.c`: drop the OUT-transaction MPS clamp in `udc_ambiq_rx()`. The
  clamp is unnecessary and breaks non-short-packet OUT transfers.

**SDIO (board pinctrl)**
- `apollo510b_evb-pinctrl.dtsi`: move `SDIF0_DAT1/DAT3` out of the unbiased
  group into the biased pull-up group alongside `DAT0/DAT2/CMD`. Without
  pull-ups on DAT1/DAT3 the 8-bit eMMC CRC fails intermittently on
  multi-block writes.

## Parity note

The board USB node, `vddusb` GPIOs, the `usbd` support tag, and the
`tests/drivers/udc` suite already matched between the branches; only these
three files differed.

## Test

Built and run on `apollo510b_evb`:

    west build -p always -b apollo510b_evb zephyr/samples/subsys/usb/mass

- Enumerates as a USB mass-storage device; SD/eMMC mounts and is
  readable/writable from a Windows host.
- Hot unplug/replug recovers cleanly (BBB reset-recovery path).
